### PR TITLE
fix(SlashCommand): 强制聚焦编辑器视图以修复滚动时焦点丢失问题

### DIFF
--- a/src/extensions/SlashCommand/SlashCommand.ts
+++ b/src/extensions/SlashCommand/SlashCommand.ts
@@ -105,6 +105,8 @@ export const SlashCommand = Extension.create({
           return {
             onStart: (props: SuggestionProps) => {
               const { view } = props.editor;
+              // 强制聚焦编辑器视图
+
               const getReferenceClientRect = () => {
                 if (!props.clientRect) {
                   return (props.editor.storage as any)[extensionName]?.rect;
@@ -145,6 +147,7 @@ export const SlashCommand = Extension.create({
               };
 
               view.dom.parentElement?.parentElement?.addEventListener('scroll', scrollHandler);
+              view.focus();
             },
 
             onUpdate(props: SuggestionProps) {

--- a/src/extensions/SlashCommand/SlashCommand.ts
+++ b/src/extensions/SlashCommand/SlashCommand.ts
@@ -105,8 +105,6 @@ export const SlashCommand = Extension.create({
           return {
             onStart: (props: SuggestionProps) => {
               const { view } = props.editor;
-              // 强制聚焦编辑器视图
-
               const getReferenceClientRect = () => {
                 if (!props.clientRect) {
                   return (props.editor.storage as any)[extensionName]?.rect;


### PR DESCRIPTION
在滚动时编辑器可能失去焦点，添加view.focus()确保始终聚焦视图

## PR 描述

**这个 PR 引入了什么变更？**

<!-- 请清晰简洁地描述所做的变更 -->

## PR 类型

<!-- 请使用 "x" 勾选适用于此 PR 的选项 -->

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 💄 UI/UX 改进
- [ ] ♻️ 重构（无功能变化）
- [ ] 🚀 性能优化
- [ ] 📝 文档更新
- [ ] 🔧 构建/CI 相关变更
- [ ] 🧪 测试相关变更
- [ ] 🔒 安全修复
- [ ] ⬆️ 依赖更新
- [ ] ⏪ 还原变更
- [ ] 🔄 其他... 请描述:

## Issue 关联

<!-- 使用以下格式关联 Issue：
- 修复 Issue: "Closes #Issue编号" 或 "Fixes #Issue编号"
- 关联 Issue: "Related to #Issue编号" -->

- Closes #<!-- Issue编号 -->
- Related to #<!-- 相关Issue编号 -->

## 实现细节

<!-- 请描述技术实现方案。您采用了什么方法？考虑过哪些替代方案？ -->

## 测试情况

<!-- 描述您已完成的测试 -->

- [ ] 已添加/更新单元测试
- [ ] 已添加/更新集成测试
- [x] 已完成手动测试

## 破坏性变更

- [ ] 是（请在下方描述影响和迁移路径）
- [ ] 否

<!-- 如果选择"是"，请解释对现有应用的影响和迁移路径 -->

## UI 变更
1. / 后出现的 popup 会导致输入时区焦点

优化前

<img width="2748" height="1316" alt="de2c2183d51fa79ebe430b268f65e7c1" src="https://github.com/user-attachments/assets/9993b6c4-ead2-4495-966d-7f0944a49d07" />

优化后

<img width="2168" height="1292" alt="image" src="https://github.com/user-attachments/assets/d8479bcb-70e6-4709-a43b-668d6764e6ab" />






<!-- 对于UI变更，请包含变更前/后的截图或视频 -->

## 部署注意事项

<!-- 部署时需要特别注意的事项？数据库迁移？环境变量？ -->

## 提交前检查清单

- [x] 我的代码符合项目的代码风格
- [x] 我已经审核了自己的代码
- [x] 我已经为复杂的代码部分添加了注释
- [x] 我已经更新了相关文档
- [x] 我的变更不会产生新的警告或错误
- [x] 我已确认所有依赖项都已正确更新

<!--
提示：
1. 请尽量使用中文填写此PR模板
3. 关联Issue时，使用 "Closes #123" 会在PR合并后自动关闭对应Issue
4. 如需在PR描述中提及团队成员，可使用 @用户名 格式
5. 请确保PR标题简洁明了地概括了变更内容
-->
