### PR TITLE
fix: 修复红色背景到公众号背景色不显示

### DIFF
--- a/src/components/panels/Colorpicker/Colorpicker.tsx
+++ b/src/components/panels/Colorpicker/Colorpicker.tsx
@@ -14,7 +14,7 @@ export type ColorPickerProps = {
 };
 
 export function ColorPicker({ color, onChange, onClear }: ColorPickerProps) {
-  const [colorInputValue, setColorInputValue] = useState(color || '');
+  const [colorInputValue, setColorInputValue] = useState(color || '#FF0000');
 
   const handleColorUpdate = (event: React.ChangeEvent<HTMLInputElement>) => {
     setColorInputValue(event.target.value);
@@ -38,7 +38,7 @@ export function ColorPicker({ color, onChange, onClear }: ColorPickerProps) {
 
   return (
     <div className="flex flex-col gap-2">
-      <HexColorPicker className="w-full" color={color || ''} onChange={onChange} />
+      <HexColorPicker className="w-full" color={color || '#FF0000'} onChange={onChange} />
       <input
         type="text"
         className="w-full p-2 text-black bg-white border rounded dark:bg-black dark:text-white border-neutral-200 dark:border-neutral-800 focus:outline-1 focus:ring-0 focus:outline-neutral-300 dark:focus:outline-neutral-700"

--- a/src/extensions/extension-kit.ts
+++ b/src/extensions/extension-kit.ts
@@ -332,7 +332,6 @@ export const ExtensionKit = ({ provider, commentCallbacks }: ExtensionKitPropsWi
 
   Emoji.configure({
     enableEmoticons: true,
-    forceFallbackImages: true,
     suggestion: emojiSuggestion,
   }),
   TextAlign.extend({


### PR DESCRIPTION
fix(Colorpicker): 将默认颜色值从空字符串改为#FF0000

## PR 描述

**这个 PR 引入了什么变更？**

<!-- 请清晰简洁地描述所做的变更 -->

## PR 类型

<!-- 请使用 "x" 勾选适用于此 PR 的选项 -->

- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 💄 UI/UX 改进
- [ ] ♻️ 重构（无功能变化）
- [ ] 🚀 性能优化
- [ ] 📝 文档更新
- [ ] 🔧 构建/CI 相关变更
- [ ] 🧪 测试相关变更
- [ ] 🔒 安全修复
- [ ] ⬆️ 依赖更新
- [ ] ⏪ 还原变更
- [ ] 🔄 其他... 请描述:

## Issue 关联

<!-- 使用以下格式关联 Issue：
- 修复 Issue: "Closes #Issue编号" 或 "Fixes #Issue编号"
- 关联 Issue: "Related to #Issue编号" -->

- Closes #<!-- Issue编号 -->
- Related to #<!-- 相关Issue编号 -->

## 实现细节
 1. 初始值给定的是空字符，导致转为16进制的时候 成为 #NaNNaNNaN， 导致复制过后没有了背景色
<!-- 请描述技术实现方案。您采用了什么方法？考虑过哪些替代方案？ -->

## 测试情况

<!-- 描述您已完成的测试 -->

- [ ] 已添加/更新单元测试
- [ ] 已添加/更新集成测试
- [x] 已完成手动测试

## 破坏性变更

- [ ] 是（请在下方描述影响和迁移路径）
- [x] 否

<!-- 如果选择"是"，请解释对现有应用的影响和迁移路径 -->

## UI 变更
公众号
<img width="1420" height="710" alt="image" src="https://github.com/user-attachments/assets/0d146ee7-bb0d-4bee-8359-bee80a9ed4f9" />


md
<img width="1574" height="504" alt="image" src="https://github.com/user-attachments/assets/380a6b0a-378d-46bf-9c4a-8abfac74c684" />



<!-- 对于UI变更，请包含变更前/后的截图或视频 -->

## 部署注意事项

<!-- 部署时需要特别注意的事项？数据库迁移？环境变量？ -->

## 提交前检查清单

- [ ] 我的代码符合项目的代码风格
- [ ] 我已经审核了自己的代码
- [ ] 我已经为复杂的代码部分添加了注释
- [ ] 我已经更新了相关文档
- [ ] 我的变更不会产生新的警告或错误
- [x] 我已确认所有依赖项都已正确更新

<!--
提示：
1. 请尽量使用中文填写此PR模板
2. 关联Issue时，使用 "Closes #123" 会在PR合并后自动关闭对应Issue
3. 如需在PR描述中提及团队成员，可使用 @用户名 格式
4. 请确保PR标题简洁明了地概括了变更内容
-->
