### PR TITLE
feat(聊天面板): 添加标签重命名功能

### DIFF
--- a/apps/DocFlow/src/app/docs/_components/ChatPanel/index.tsx
+++ b/apps/DocFlow/src/app/docs/_components/ChatPanel/index.tsx
@@ -288,6 +288,10 @@ export function ChatPanel({ className }: ChatPanelProps) {
     removeTab(tabId);
   };
 
+  const handleRenameTab = (tabId: string, newTitle: string) => {
+    updateTab(tabId, { title: newTitle });
+  };
+
   const handleOpenSession = (session: { id: string; title: string }) => {
     const existing = tabs.find((t) => t.conversationId === session.id);
 
@@ -477,6 +481,7 @@ export function ChatPanel({ className }: ChatPanelProps) {
         onNewTab={handleNewTab}
         onSwitchTab={handleSwitchTab}
         onCloseTab={handleCloseTab}
+        onRenameTab={handleRenameTab}
         onOpenSession={handleOpenSession}
         onRefreshSessions={refreshSessions}
         onClosePanel={() => setIsOpen(false)}

--- a/apps/DocFlow/src/stores/chatStore.ts
+++ b/apps/DocFlow/src/stores/chatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 export interface ChatTab {
   id: string;
@@ -29,6 +30,7 @@ interface ChatState {
   updateTab: (id: string, updates: Partial<Omit<ChatTab, 'id'>>) => void;
   setDocumentReference: (reference: DocumentReference | null) => void;
   setPresetMessage: (message: string | null) => void;
+  onRenameTab: (id: string, newTitle: string) => void;
 }
 
 let tabCounter = 0;
@@ -39,77 +41,115 @@ function createTabId(): string {
   return `tab-${tabCounter}-${Date.now()}`;
 }
 
-export const useChatStore = create<ChatState>((set, get) => ({
-  isOpen: true,
-  tabs: [],
-  activeTabId: null,
-  documentReference: null,
-  presetMessage: null,
+export const useChatStore = create<ChatState>()(
+  persist(
+    (set) => ({
+      isOpen: true,
+      tabs: [],
+      activeTabId: null,
+      documentReference: null,
+      presetMessage: null,
 
-  setIsOpen: (isOpen) => {
-    set({ isOpen });
+      setIsOpen: (isOpen) => {
+        set((state) => {
+          if (isOpen && state.tabs.length === 0) {
+            const id = createTabId();
+            const newTab: ChatTab = {
+              id,
+              title: '新对话',
+              conversationId: null,
+            };
 
-    if (isOpen && get().tabs.length === 0) {
-      get().addTab();
-    }
-  },
+            return {
+              isOpen,
+              tabs: [newTab],
+              activeTabId: id,
+            };
+          }
 
-  togglePanel: () => {
-    const next = !get().isOpen;
-    set({ isOpen: next });
+          return { isOpen };
+        });
+      },
 
-    if (next && get().tabs.length === 0) {
-      get().addTab();
-    }
-  },
+      togglePanel: () => {
+        set((state) => {
+          const next = !state.isOpen;
 
-  addTab: (tab) => {
-    const id = createTabId();
-    const newTab: ChatTab = {
-      id,
-      title: tab?.title || '新对话',
-      conversationId: tab?.conversationId || null,
-    };
+          if (next && state.tabs.length === 0) {
+            const id = createTabId();
+            const newTab: ChatTab = {
+              id,
+              title: '新对话',
+              conversationId: null,
+            };
 
-    set((state) => ({
-      tabs: [...state.tabs, newTab],
-      activeTabId: id,
-    }));
+            return {
+              isOpen: next,
+              tabs: [newTab],
+              activeTabId: id,
+            };
+          }
 
-    return id;
-  },
+          return { isOpen: next };
+        });
+      },
 
-  removeTab: (id) => {
-    set((state) => {
-      const newTabs = state.tabs.filter((t) => t.id !== id);
-      let newActiveId = state.activeTabId;
+      addTab: (tab) => {
+        const id = createTabId();
+        const newTab: ChatTab = {
+          id,
+          title: tab?.title || '新对话',
+          conversationId: tab?.conversationId || null,
+        };
 
-      if (state.activeTabId === id) {
-        const removedIndex = state.tabs.findIndex((t) => t.id === id);
+        set((state) => ({
+          tabs: [...state.tabs, newTab],
+          activeTabId: id,
+        }));
 
-        if (newTabs.length > 0) {
-          newActiveId = newTabs[Math.min(removedIndex, newTabs.length - 1)].id;
-        } else {
-          newActiveId = null;
-        }
-      }
+        return id;
+      },
 
-      return {
-        tabs: newTabs,
-        activeTabId: newActiveId,
-        isOpen: newTabs.length > 0 ? state.isOpen : false,
-      };
-    });
-  },
+      removeTab: (id) => {
+        set((state) => {
+          const newTabs = state.tabs.filter((t) => t.id !== id);
+          let newActiveId = state.activeTabId;
 
-  setActiveTab: (id) => set({ activeTabId: id }),
+          if (state.activeTabId === id) {
+            const removedIndex = state.tabs.findIndex((t) => t.id === id);
 
-  updateTab: (id, updates) =>
-    set((state) => ({
-      tabs: state.tabs.map((t) => (t.id === id ? { ...t, ...updates } : t)),
-    })),
+            if (newTabs.length > 0) {
+              newActiveId = newTabs[Math.min(removedIndex, newTabs.length - 1)].id;
+            } else {
+              newActiveId = null;
+            }
+          }
 
-  setDocumentReference: (reference) => set({ documentReference: reference }),
+          return {
+            tabs: newTabs,
+            activeTabId: newActiveId,
+            isOpen: newTabs.length > 0 ? state.isOpen : false,
+          };
+        });
+      },
 
-  setPresetMessage: (message) => set({ presetMessage: message }),
-}));
+      setActiveTab: (id) => set({ activeTabId: id }),
+
+      updateTab: (id, updates) =>
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === id ? { ...t, ...updates } : t)),
+        })),
+      onRenameTab: (id, newTitle) =>
+        set((state) => ({
+          tabs: state.tabs.map((t) => (t.id === id ? { ...t, title: newTitle } : t)),
+        })),
+
+      setDocumentReference: (reference) => set({ documentReference: reference }),
+
+      setPresetMessage: (message) => set({ presetMessage: message }),
+    }),
+    {
+      name: 'chat-storage',
+    },
+  ),
+);


### PR DESCRIPTION
实现通过双击标签进入编辑模式并重命名的功能
添加相关状态管理和事件处理逻辑

## PR 描述

<!-- 描述这个 PR 的变更内容 -->
1.  添加标签重命名
2. 增加标签的持久化

## PR 类型

- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 💄 UI/UX 改进
- [ ] ♻️ 重构
- [ ] 🚀 性能优化
- [ ] 📝 文档更新
- [ ] 🔄 其他

## Issue 关联

<!-- 使用 "Closes #123" 或 "Fixes #123" 关联 Issue -->

Closes #

## 其他信息

<!-- 实现细节、测试情况、破坏性变更、UI 截图、部署注意事项等（可选） -->
<img width="568" height="401" alt="image" src="https://github.com/user-attachments/assets/d6da8a89-304b-414e-9436-927455799a9b" />

