### PR TITLE
fix(DocFlow): 更新WebSocket URL以使用协作服务端点

### DIFF
--- a/apps/DocFlow/.env.development
+++ b/apps/DocFlow/.env.development
@@ -2,7 +2,9 @@ NEXT_PUBLIC_AUTH_LOGIN_URL = https://api.codecrack.cn/api/v1/auth/github
 
 NEXT_PUBLIC_SERVER_URL = https://api.codecrack.cn
 
-NEXT_PUBLIC_WEBSOCKET_URL = wss://ws.codecrack.cn
+# NEXT_PUBLIC_WEBSOCKET_URL = wss://ws.codecrack.cn
+
+NEXT_PUBLIC_WEBSOCKET_URL = wss://api.codecrack.cn/collaboration
 
 NEXT_PUBLIC_NOTIFICATION_WEBSOCKET_URL = https://note.codecrack.cn
 

--- a/apps/DocFlow/.env.production
+++ b/apps/DocFlow/.env.production
@@ -2,7 +2,9 @@ NEXT_PUBLIC_AUTH_LOGIN_URL = https://api.codecrack.cn/api/v1/auth/github
 
 NEXT_PUBLIC_SERVER_URL = https://api.codecrack.cn
 
-NEXT_PUBLIC_WEBSOCKET_URL = wss://ws.codecrack.cn
+# NEXT_PUBLIC_WEBSOCKET_URL = wss://ws.codecrack.cn
+
+NEXT_PUBLIC_WEBSOCKET_URL = wss://api.codecrack.cn/collaboration
 
 NEXT_PUBLIC_NOTIFICATION_WEBSOCKET_URL = https://note.codecrack.cn
 


### PR DESCRIPTION
将生产环境和开发环境中的WebSocket URL从ws.codecrack.cn更改为api.codecrack.cn/collaboration，以统一使用协作服务端点

## PR 描述

<!-- 描述这个 PR 的变更内容 -->

## PR 类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 💄 UI/UX 改进
- [ ] ♻️ 重构
- [ ] 🚀 性能优化
- [ ] 📝 文档更新
- [ ] 🔄 其他

## Issue 关联

<!-- 使用 "Closes #123" 或 "Fixes #123" 关联 Issue -->

Closes #
更新WebSocket URL以使用协作服务端点
## 其他信息

<!-- 实现细节、测试情况、破坏性变更、UI 截图、部署注意事项等（可选） -->
