### PR TITLE
feat(编辑器): 实现自定义Tab键处理逻辑并移除冗余表格扩展

### DIFF
--- a/apps/DocFlow/src/app/docs/[room]/page.tsx
+++ b/apps/DocFlow/src/app/docs/[room]/page.tsx
@@ -328,6 +328,34 @@ export default function DocumentPage() {
           class: 'min-h-full',
           spellcheck: 'false',
         },
+        handleKeyDown: (view, event) => {
+          if (event.key === 'Tab') {
+            if (event.shiftKey) {
+              const { state } = view;
+              const { from } = state.selection;
+              const $from = state.doc.resolve(from);
+              const startOfLine = $from.start($from.depth);
+              const textBeforeCursor = state.doc.textBetween(startOfLine, from);
+
+              if (textBeforeCursor.endsWith('  ')) {
+                const deleteFrom = Math.max(startOfLine, from - 2);
+                view.dispatch(state.tr.deleteRange(deleteFrom, from));
+
+                return true;
+              } else if (textBeforeCursor.endsWith(' ')) {
+                view.dispatch(state.tr.deleteRange(from - 1, from));
+
+                return true;
+              }
+            } else {
+              view.dispatch(view.state.tr.insertText('  '));
+
+              return true;
+            }
+          }
+
+          return false;
+        },
       },
       immediatelyRender: false,
       shouldRerenderOnTransaction: false,

--- a/apps/DocFlow/src/extensions/extension-kit.ts
+++ b/apps/DocFlow/src/extensions/extension-kit.ts
@@ -39,9 +39,6 @@ import {
   Superscript,
   TableKit,
   TableOfContents,
-  TableCell,
-  TableHeader,
-  TableRow,
   TextAlign,
   TextStyle,
   TrailingNode,
@@ -318,32 +315,7 @@ export const ExtensionKit = ({ provider }: ExtensionKitProps) => [
     enableEmoticons: true,
     suggestion: emojiSuggestion,
   }),
-  TextAlign.extend({
-    addKeyboardShortcuts() {
-      return {
-        Tab: () => {
-          return this.editor.commands.insertContent('  ');
-        },
-        'Shift-Tab': () => {
-          const { state } = this.editor;
-          const { from } = state.selection;
-          const $from = state.doc.resolve(from);
-          const startOfLine = $from.start($from.depth);
-          const textBeforeCursor = state.doc.textBetween(startOfLine, from);
-
-          if (textBeforeCursor.endsWith('  ')) {
-            const deleteFrom = Math.max(startOfLine, from - 2);
-
-            return this.editor.commands.deleteRange({ from: deleteFrom, to: from });
-          } else if (textBeforeCursor.endsWith(' ')) {
-            return this.editor.commands.deleteRange({ from: from - 1, to: from });
-          }
-
-          return false;
-        },
-      };
-    },
-  }).configure({
+  TextAlign.configure({
     types: ['heading', 'paragraph'],
   }),
   Subscript,
@@ -353,9 +325,6 @@ export const ExtensionKit = ({ provider }: ExtensionKitProps) => [
       resizable: true,
     },
   }),
-  TableCell,
-  TableHeader,
-  TableRow,
   Typography,
   Placeholder.configure({
     includeChildren: true,


### PR DESCRIPTION
将Tab键处理逻辑从TextAlign扩展迁移到页面组件中，实现更精细的控制
移除未使用的表格相关扩展(TableCell, TableHeader, TableRow)

## PR 描述

fix: 在 TipTap 3.x 版本中， @tiptap/extension-text-align 的 .extend() 方法在某些情况下会返回 undefined ，导致后续调用 .configure() 时报错 Cannot read properties of undefined (reading 'configure') 。

<!-- 描述这个 PR 的变更内容 -->

## PR 类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 💄 UI/UX 改进
- [ ] ♻️ 重构
- [ ] 🚀 性能优化
- [ ] 📝 文档更新
- [ ] 🔄 其他

## Issue 关联

<!-- 使用 "Closes #123" 或 "Fixes #123" 关联 Issue -->

Closes #

## 其他信息

<!-- 实现细节、测试情况、破坏性变更、UI 截图、部署注意事项等（可选） -->
